### PR TITLE
Singleton Migration and QuitCommand fix

### DIFF
--- a/Commands/QuitCommand.cpp
+++ b/Commands/QuitCommand.cpp
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   QuitCommand.cpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: davi <davi@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/12 00:35:11 by davi              #+#    #+#             */
-/*   Updated: 2025/03/12 00:42:00 by davi             ###   ########.fr       */
+/*   Updated: 2025/03/23 12:27:25 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "QuitCommand.hpp"
+#include "../Core/Events.hpp"
+
 
 QuitCommand::QuitCommand(UserService& userService, ChannelService& channelService)
                         :_userService(&userService), _channelService(&channelService)
@@ -30,4 +32,5 @@ void QuitCommand::execute(MessageContent messageContent, int fd)
     
     std::cout << "[DEBUG]: COMANDO QUIT SENDO CHAMADO" << std::endl;
     _userService->RemoveUserByFd(fd);
+    Events::getInstance()->removeClient(fd);
 }

--- a/Commands/UserCommand.cpp
+++ b/Commands/UserCommand.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   UserCommand.cpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: artuda-s <artuda-s@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/11 13:55:58 by dmelo-ca          #+#    #+#             */
-/*   Updated: 2025/03/17 17:46:06 by artuda-s         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:03:08 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,11 +54,11 @@ void UserCommand::execute(MessageContent messageContent, int fd)
     }
     
     // USER || USER user user2 (:...)
-    if (messageContent.tokens.size() != 2)
+/*     if (messageContent.tokens.size() != 2)
     {
         std::cerr << "461 bad user"  << std::endl; // TODO proper error handling
         return ;
-    }    
+    }    */ 
     
     // set username
     //? fd entry was created when the connection was established and now were setting the username to that fd

--- a/Core/Events.cpp
+++ b/Core/Events.cpp
@@ -3,14 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   Events.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lebarbos <lebarbos@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/08 20:56:17 by davi              #+#    #+#             */
-/*   Updated: 2025/03/19 17:27:11 by lebarbos         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:05:44 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Events.hpp"
+
+
+// INICIANDO A VARIAVEL INSTANCE DO SINGLETON
+Events* Events::_instance = NULL;
 
 //! CODIGO BASEADO NA DOCUMENTACAO - MAN EPOLL
 
@@ -24,6 +28,18 @@ Events::~Events()
 {
 }
 
+Events* Events::getInstance(int socketFd)
+{
+    if (!_instance)
+        _instance = new Events(socketFd);
+    return _instance;
+}
+
+Events* Events::getInstance()
+{
+    return _instance;
+}
+
 // TODO: TALVEZ ADICIONAR EXCEPTIONS PERSONALIZADAS PARA SO UTILIZAR TRY/CATCH NO CONSTRUTOR
 // TODO: ERROR CHECKING ?
 bool Events::setupPollContext()
@@ -34,7 +50,6 @@ bool Events::setupPollContext()
     pfd.revents = 0;                // no events initially
 
     this->_pfds.push_back(pfd);     // add this pollfd to the vector of pollfds
-
     return true;
 }
 

--- a/Core/Events.hpp
+++ b/Core/Events.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Events.hpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: artuda-s <artuda-s@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/08 21:52:12 by davi              #+#    #+#             */
-/*   Updated: 2025/03/13 18:20:04 by artuda-s         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:24:48 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,16 +31,21 @@ class Events
 private:
     int _listensocket;
     std::vector<struct pollfd> _pfds;
+    
+    Events(int socketFd);
+    
+    static Events* _instance;
 
     MessageHandler _msgHandler;
     
     bool setupPollContext();
     bool setNonBlock(int targetFd);
     void readAndPrintFd(int fd);
-    void removeClient(int fd);
 public:
-    Events(int socketFd);
     ~Events();
 
+    static Events* getInstance();
+    static Events* getInstance(int socketFd);
+    void removeClient(int fd);
     void runPollLoop();
 };

--- a/Handlers/MessageHandler.cpp
+++ b/Handlers/MessageHandler.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   MessageHandler.cpp                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lebarbos <lebarbos@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/09 12:04:19 by davi              #+#    #+#             */
-/*   Updated: 2025/03/22 12:37:02 by lebarbos         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:22:39 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,8 @@
 */
 
 
-MessageHandler::MessageHandler()
+MessageHandler::MessageHandler() 
+        : _userService(UserService::getInstance()), _channelService(ChannelService::getInstance())
 {
     RegisterCommands();
 }

--- a/Handlers/MessageHandler.hpp
+++ b/Handlers/MessageHandler.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   MessageHandler.hpp                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lebarbos <lebarbos@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/09 12:04:03 by davi              #+#    #+#             */
-/*   Updated: 2025/03/21 10:31:18 by lebarbos         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:20:24 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,8 @@ private:
     std::string getMessage(std::string& buffer, std::size_t it);
     std::string getMessage(std::string& strBegin, std::istringstream& stream);
 
-    UserService _userService;
-    ChannelService _channelService;
+    UserService& _userService;
+    ChannelService& _channelService;
     cmdsMap _commands;
 
     std::vector<std::string> splitDeVariosComandos(std::string &buffer);

--- a/Services/ChannelService.cpp
+++ b/Services/ChannelService.cpp
@@ -3,14 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   ChannelService.cpp                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: davi <davi@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/11 01:04:45 by davi              #+#    #+#             */
-/*   Updated: 2025/03/12 01:06:25 by davi             ###   ########.fr       */
+/*   Updated: 2025/03/23 12:21:29 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ChannelService.hpp"
+
+
+// INICIANDO A VARIAVEL INSTANCE DO SINGLETON
+ChannelService* ChannelService::_instance = NULL;
 
 /* 
     ESSA CLASSE TEM O PROPOSITO DE GERENCIAR E IMPLEMENTAR METHODOS PARA
@@ -30,6 +34,13 @@ ChannelService::ChannelService(/* args */)
 
 ChannelService::~ChannelService()
 {
+}
+
+ChannelService& ChannelService::getInstance()
+{
+    if (!_instance)
+        _instance = new ChannelService();
+    return *_instance;
 }
 
 /* 

--- a/Services/ChannelService.hpp
+++ b/Services/ChannelService.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ChannelService.hpp                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: davi <davi@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/11 01:04:53 by davi              #+#    #+#             */
-/*   Updated: 2025/03/12 01:00:17 by davi             ###   ########.fr       */
+/*   Updated: 2025/03/23 12:19:21 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,9 +36,15 @@ class ChannelService
 private:
     // channelName - Channel*
     std::map<std::string, Channel*> _channels;
-public:
+    
     ChannelService(/* args */);
+
+    static ChannelService* _instance;
+    
+public:
     ~ChannelService();
+
+    static ChannelService& getInstance();
 
     Channel *get_or_createChannel(std::string channelName);
 

--- a/Services/UserService.cpp
+++ b/Services/UserService.cpp
@@ -3,16 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   UserService.cpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lebarbos <lebarbos@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/09 21:06:28 by davi              #+#    #+#             */
-/*   Updated: 2025/03/22 12:38:40 by lebarbos         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:21:49 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "UserService.hpp"
 #include <cerrno>
 #include <cstring>
+
+// INICIANDO A VARIAVEL INSTANCE DO SINGLETON
+UserService* UserService::_instance = NULL;
 
 /* 
     ESSA CLASSE TEM O PROPOSITO DE GERENCIAR E IMPLEMENTAR METHODOS PARA
@@ -43,6 +46,13 @@ UserService::~UserService()
 void UserService::CreateUserByFd(int fd)
 {
     _usersByFd[fd] = new User(fd);
+}
+
+UserService& UserService::getInstance()
+{
+    if (!_instance)
+        _instance = new UserService();
+    return *_instance;
 }
 
 

--- a/Services/UserService.hpp
+++ b/Services/UserService.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   UserService.hpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lebarbos <lebarbos@student.42porto.com>    +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/09 21:07:28 by davi              #+#    #+#             */
-/*   Updated: 2025/03/21 10:20:10 by lebarbos         ###   ########.fr       */
+/*   Updated: 2025/03/23 12:20:16 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,10 +38,15 @@ private:
     // Infelizmente redundante porem otimizado para buscas
     std::map<int, User*> _usersByFd;
     std::map<std::string, User*> _userByNick;
+    
+    UserService();
+
+    static UserService* _instance;
 
 public:
-    UserService();
     ~UserService();
+
+    static UserService& getInstance();
 
     User* findUserByFd(int fd);
     User* findUserByNickname(std::string nickname);

--- a/main.cpp
+++ b/main.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fang <fang@student.42.fr>                  +#+  +:+       +#+        */
+/*   By: dmelo-ca <dmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/08 19:33:54 by davi              #+#    #+#             */
-/*   Updated: 2025/03/16 20:25:05 by fang             ###   ########.fr       */
+/*   Updated: 2025/03/23 12:08:58 by dmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,8 +32,8 @@ int main(int ac, char **av)
     {
         Server::getInstance().setPassword(av[2]);
         Socket ioContext(atoi(av[1]));
-        Events pollContext(ioContext.getSocketFd());
-        pollContext.runPollLoop();
+        Events::getInstance(ioContext.getSocketFd());
+        Events::getInstance()->runPollLoop();
     }
     catch(const std::exception& e)
     {


### PR DESCRIPTION
Migration of events, UserService, ChannelService to appropriated singleton using static, but still need a refac in commands to remove redundant code and QuitCommand uses this singleton features of Events to remove a clientFd from poll vector after remove user instance from UserService 